### PR TITLE
p4 username & env-based shebang

### DIFF
--- a/p4-annotate
+++ b/p4-annotate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: prints p4 information of a specific changelist
 # Author: Arnon Zilca

--- a/p4-delete-changelist
+++ b/p4-delete-changelist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: deletes a p4 changelist completely.
 #              removes its shelve, reverts the files

--- a/p4-delete-client
+++ b/p4-delete-client
@@ -36,11 +36,11 @@ while getopts "h?fc:n" opt; do
             ;;
         c)
             CLIENT_NAME=${OPTARG}
-            CLIENT_FULL_STRING=$(p4 clients -u $USERNAME | grep "${CLIENT_NAME}")
+            CLIENT_FULL_STRING=$(p4 clients -u ${USERNAME} | grep "${CLIENT_NAME}")
             CLIENT_NAME=$(echo ${CLIENT_FULL_STRING} | awk '{print $2}')
             if [[ -z "${CLIENT_NAME}" ]]; then
                 echo -e "${RED}Couldn't find client: ${CLIENT_NAME}" >&2
-                echo -e "Or client doesn't belong to you ($USERNAME)${NO_COLOR}" >&2
+                echo -e "Or client doesn't belong to you (${USERNAME})${NO_COLOR}" >&2
                 usage
                 exit 2
             fi
@@ -82,7 +82,7 @@ if [[ -n "${NO_FILES}" || ! -d "${CLIENT_PATH}" ]]; then
     CLIENT_PATH=
 fi
 
-changelists=$(p4 changes -s pending -u $USERNAME -c "${CLIENT_NAME}")   # split inorder to catch a login error.
+changelists=$(p4 changes -s pending -u ${USERNAME} -c "${CLIENT_NAME}")   # split inorder to catch a login error.
 changelists=$(echo "${changelists}" | awk '{print $2}')
 
 echo -e "Attempting to delete client: ${CYAN}${CLIENT_NAME}${NO_COLOR}"

--- a/p4-delete-client
+++ b/p4-delete-client
@@ -11,6 +11,8 @@ SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 source "${SCRIPT_PATH}/p4-help-functions"
 
+USERNAME=$(p4-guess-username)
+
 usage() {
     echo -en "${NO_COLOR}" >&2
     echo    "$(basename $0) -- deletes a p4 client completely" >&2
@@ -34,11 +36,11 @@ while getopts "h?fc:n" opt; do
             ;;
         c)
             CLIENT_NAME=${OPTARG}
-            CLIENT_FULL_STRING=$(p4 clients -u $USER | grep "${CLIENT_NAME}")
+            CLIENT_FULL_STRING=$(p4 clients -u $USERNAME | grep "${CLIENT_NAME}")
             CLIENT_NAME=$(echo ${CLIENT_FULL_STRING} | awk '{print $2}')
             if [[ -z "${CLIENT_NAME}" ]]; then
                 echo -e "${RED}Couldn't find client: ${CLIENT_NAME}" >&2
-                echo -e "Or client doesn't belong to you ($USER)${NO_COLOR}" >&2
+                echo -e "Or client doesn't belong to you ($USERNAME)${NO_COLOR}" >&2
                 usage
                 exit 2
             fi
@@ -80,7 +82,7 @@ if [[ -n "${NO_FILES}" || ! -d "${CLIENT_PATH}" ]]; then
     CLIENT_PATH=
 fi
 
-changelists=$(p4 changes -s pending -u $USER -c "${CLIENT_NAME}")   # split inorder to catch a login error.
+changelists=$(p4 changes -s pending -u $USERNAME -c "${CLIENT_NAME}")   # split inorder to catch a login error.
 changelists=$(echo "${changelists}" | awk '{print $2}')
 
 echo -e "Attempting to delete client: ${CYAN}${CLIENT_NAME}${NO_COLOR}"

--- a/p4-delete-client
+++ b/p4-delete-client
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: deletes a p4 client completely
 # Author: Arnon Zilca

--- a/p4-delete-client
+++ b/p4-delete-client
@@ -11,7 +11,7 @@ SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 source "${SCRIPT_PATH}/p4-help-functions"
 
-USERNAME=$(p4-guess-username)
+USERNAME=$(p4-resolve-username)
 
 usage() {
     echo -en "${NO_COLOR}" >&2

--- a/p4-help-functions
+++ b/p4-help-functions
@@ -189,7 +189,7 @@ p4-pick-client() {
     echo ${clients[${result}]}
 }
 
-function p4-guess-username() {
+function p4-resolve-username() {
     USERNAME=$(p4-user-name)
     if [[ -z "${USERNAME}" ]]; then
         USERNAME=${USER}

--- a/p4-help-functions
+++ b/p4-help-functions
@@ -54,6 +54,11 @@ promptyn() {
     done
 }
 
+p4-user-name() {
+    local USER_NAME_FIELD="User name: "
+    p4 info | grep "${USER_NAME_FIELD}" | sed "s/${USER_NAME_FIELD}//g"
+}
+
 p4-client-name() {
     local CLIENT_NAME_FIELD="Client name: "
     p4 info | grep "${CLIENT_NAME_FIELD}" | sed "s/${CLIENT_NAME_FIELD}//g"
@@ -182,4 +187,12 @@ p4-pick-client() {
 
     echo >&2
     echo ${clients[${result}]}
+}
+
+function p4-guess-username() {
+    USERNAME=$(p4-user-name)
+    if [[ -z "${USERNAME}" ]]; then
+        USERNAME=${USER}
+    fi
+    echo ${USERNAME}
 }

--- a/p4-help-functions
+++ b/p4-help-functions
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: holds helper functions for p4 scripts
 # Author: Arnon Zilca

--- a/p4-reshelve
+++ b/p4-reshelve
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: reshelves a p4 shelved changelist
 #              deletes the current shevlve of a p4 changelist and

--- a/p4-revert-all-opened
+++ b/p4-revert-all-opened
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: prints p4 changelists information (formatted and colored)
 # Author: Arnon Zilca

--- a/p4-show
+++ b/p4-show
@@ -44,7 +44,7 @@ usage() {
     echo    "  -l           skip changelists limit check (${NUMBER_OF_CHANGELISTS_LIMIT})" >&2
     echo    "  -m max       show the 'max' most recent changelists (default changelist won't be shown)" >&2
     echo    "  -c client    filter by client" >&2
-    echo    "  -u user      filter by user (the default in your case is ${USER})" >&2
+    echo    "  -u user      filter by user (the default in your case is $(p4-guess-username))" >&2
 }
 
 show-default-changelist() {
@@ -159,7 +159,7 @@ fi
 print_progress +
 
 if [[ -z "${USER_OVERRIDE}" ]]; then
-    USER_OVERRIDE="${USER}"
+    USER_OVERRIDE=$(p4-guess-username)
 fi
 
 if [[ -n ${FORCE_VERBOSE} ]]; then  # verbose takes precendence over brief

--- a/p4-show
+++ b/p4-show
@@ -44,7 +44,7 @@ usage() {
     echo    "  -l           skip changelists limit check (${NUMBER_OF_CHANGELISTS_LIMIT})" >&2
     echo    "  -m max       show the 'max' most recent changelists (default changelist won't be shown)" >&2
     echo    "  -c client    filter by client" >&2
-    echo    "  -u user      filter by user (the default in your case is $(p4-guess-username))" >&2
+    echo    "  -u user      filter by user (the default in your case is $(p4-resolve-username))" >&2
 }
 
 show-default-changelist() {
@@ -159,7 +159,7 @@ fi
 print_progress +
 
 if [[ -z "${USER_OVERRIDE}" ]]; then
-    USER_OVERRIDE=$(p4-guess-username)
+    USER_OVERRIDE=$(p4-resolve-username)
 fi
 
 if [[ -n ${FORCE_VERBOSE} ]]; then  # verbose takes precendence over brief

--- a/p4-show
+++ b/p4-show
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: prints p4 changelists information (formatted and colored)
 # Author: Arnon Zilca

--- a/p4-show-changelist
+++ b/p4-show-changelist
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: prints p4 information of a specific changelist
 # Author: Arnon Zilca

--- a/p4-switch-context
+++ b/p4-switch-context
@@ -143,7 +143,7 @@ if [[ -z "${SUPPRESS_DEFAULT_CHANGELIST_WARNING}" ]] && has-default-changelist; 
     fi
 fi
 
-USERNAME=$(p4-guess-username)
+USERNAME=$(p4-resolve-username)
 changelists=$(p4 changes -s pending -u ${USERNAME} -c ${CLIENT_NAME})
 changelists=$(echo "${changelists}" | awk '{print $2}')
 

--- a/p4-switch-context
+++ b/p4-switch-context
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: changes perforce context
 #  (shelving all pending and unshelving certain changelists if passed as an argument)

--- a/p4-switch-context
+++ b/p4-switch-context
@@ -143,7 +143,8 @@ if [[ -z "${SUPPRESS_DEFAULT_CHANGELIST_WARNING}" ]] && has-default-changelist; 
     fi
 fi
 
-changelists=$(p4 changes -s pending -u ${USER} -c ${CLIENT_NAME})
+USERNAME=$(p4-guess-username)
+changelists=$(p4 changes -s pending -u ${USERNAME} -c ${CLIENT_NAME})
 changelists=$(echo "${changelists}" | awk '{print $2}')
 
 if [[ -z "${changelists}" ]]; then

--- a/p4-unshelve
+++ b/p4-unshelve
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: unshelves a p4 changelist to its own changelist
 # Author: Arnon Zilca

--- a/p4-untracked
+++ b/p4-untracked
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Description: finds untracked (unadded) files in a p4 dir
 # Author: Arnon Zilca


### PR DESCRIPTION
1. Will attempt to get the username from “p4 info” command, and if it is not found, will fall back to $USER like it used to be.
2. Updated to use the env version of bash, rather than hard coded to
/bin/bash. It is very useful on OSX that comes with 2007 version of Bash in
/usr/bash