### PR TITLE
p4-pick-changelist compatible with OSX

### DIFF
--- a/p4-help-functions
+++ b/p4-help-functions
@@ -101,7 +101,7 @@ p4-pick-changelist() {
     SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
     local CHANGELIST_REGEX="Change [0-9]\+ by"
-    local CHANGELIST_NUMBER_REGEX="^.*Change \([0-9]\+\) by.*"
+    local CHANGELIST_NUMBER_REGEX="^.*Change ([0-9]+) by.*"
     local DEFAULT_REGEX="Default changelist"
 
     local VERB="$1"
@@ -119,7 +119,7 @@ p4-pick-changelist() {
         if echo "${line}" | grep "${CHANGELIST_REGEX}" > /dev/null; then
             ((index += 1))
             echo -e "(${index}) ${line}" >&2
-            changelists[${index}]=$(echo "${line}" | sed "s/${CHANGELIST_NUMBER_REGEX}/\1/")
+            changelists[${index}]=$(echo "${line}" | sed -E "s/${CHANGELIST_NUMBER_REGEX}/\1/")
         else
             echo "${line}" >&2
         fi


### PR DESCRIPTION
BSD and GNU versions of `sed` have small differences.
Using `sed 's/^.*Change \([0-9]\+\) by.*/\1/'` doesn't work with the BSD version (OSX).
However, using `sed -E 's/^.*Change ([0-9]+) by.*/\1/'` works on both versions.
This fixes the garbage I was seeing on OSX as described in #4 
